### PR TITLE
refactor: remove obsolete dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
       "devDependencies": {
         "@types/apca-w3": "^0.1.3",
         "@types/chroma-js": "^2.4.3",
-        "@types/prettier": "^3.0.0",
         "@types/react": "^18.2.48",
         "@types/react-color": "^3.0.11",
         "@types/react-dom": "^18.2.18",
@@ -1265,16 +1264,6 @@
       "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@types/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==",
-      "deprecated": "This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "prettier": "*"
       }
     },
     "node_modules/@types/prop-types": {
@@ -5240,15 +5229,6 @@
       "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
       "requires": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "@types/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==",
-      "dev": true,
-      "requires": {
-        "prettier": "*"
       }
     },
     "@types/prop-types": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@types/apca-w3": "^0.1.3",
     "@types/chroma-js": "^2.4.3",
-    "@types/prettier": "^3.0.0",
     "@types/react": "^18.2.48",
     "@types/react-color": "^3.0.11",
     "@types/react-dom": "^18.2.18",


### PR DESCRIPTION
`npm WARN deprecated @types/prettier@3.0.0: This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.`