### PR TITLE
fix: removed redundant root wrapper

### DIFF
--- a/src/utils/outputs/index.ts
+++ b/src/utils/outputs/index.ts
@@ -105,10 +105,8 @@ export const getFullColorCss = (
   colorsPalette: string,
   colorsSpeakingNames: string,
 ): string => {
-  return `:root{
-      ${colorsPalette}
+  return `${colorsPalette}
       ${colorsSpeakingNames}
-      }
       
 [data-color-scheme="light"] {
 	color-scheme: light;


### PR DESCRIPTION
currently if you're generating the files, a redundant `:root` wrapper / context would get generated:
- go to https://db-ui.github.io/theme-builder/main/customization
- just "Export" the current stack of configuration
- you'll recognize that there's a redundant `:root` declaration within the file `Web/Deutsche BahnTheme-colors-full.css`, compare to the following screenshot

<img width="840" alt="image" src="https://github.com/user-attachments/assets/6a4a3208-8207-4874-a302-10cc1b885143">
