### PR TITLE
Change runner to Ubuntu 24.04 in auto-assign workflow

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   add_labels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
     steps:
       - uses: actions-ecosystem/action-add-assignees@v1
         if: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
Updated the workflow to use Ubuntu 24.04 explicitly.